### PR TITLE
move cmake_minimum_required() to the top of CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(libwolv)
 cmake_minimum_required(VERSION 3.20)
+project(libwolv)
 
 if (TARGET libwolv-types)
     return ()


### PR DESCRIPTION
Really small PR to remove a CMake warning, because `cmake_minimum_required()` was not the first instruction in CMakeListst.txt