### PR TITLE
Add missing header for gcc-14

### DIFF
--- a/libs/net/source/net/socket_server.cpp
+++ b/libs/net/source/net/socket_server.cpp
@@ -2,6 +2,7 @@
 
 #include <wolv/utils/guards.hpp>
 
+#include <algorithm>
 #include <cstring>
 #include <iterator>
 #include <fcntl.h>


### PR DESCRIPTION
Need to include \<algorithm\> explicitly in order to build with GCC 14.
https://gcc.gnu.org/gcc-14/porting_to.html

```
/var/tmp/portage/app-editors/imhex-1.32.2/work/ImHex/lib/external/libwolv/libs/net/source/net/socket_server.cpp:144:22: error: ‘copy_n’ is not a member of ‘std’; did you mean ‘copy’?
  144 |                 std::copy_n(buffer.begin(), receivedByteCount, std::back_inserter(data));
      |                      ^~~~~~
      |                      copy
```