### PR TITLE
Expose additional NSBundle relative paths

### DIFF
--- a/libs/io/include/wolv/io/fs.hpp
+++ b/libs/io/include/wolv/io/fs.hpp
@@ -75,6 +75,9 @@ namespace wolv::io::fs {
 
     #if defined(OS_MACOS)
 
+    std::fs::path getMainBundleResourcesDirectoryPath();
+    std::fs::path getMainBundleBuiltInPlugInsDirectoryPath();
+
     std::fs::path getApplicationSupportDirectoryPath();
 
     #endif

--- a/libs/io/include/wolv/io/fs_macos.hpp
+++ b/libs/io/include/wolv/io/fs_macos.hpp
@@ -2,9 +2,15 @@
 
 #if defined(OS_MACOS)
 
-    extern "C" char * getMacExecutableDirectoryPath();
-    extern "C" char * getMacApplicationSupportDirectoryPath();
+    extern "C" {
+        char* getMacExecutableDirectoryPath();
+    
+        char* getMacMainBundleResourcesDirectoryPath();
+        char* getMacMainBundleBuiltInPlugInsDirectoryPath();
 
-    extern "C" void macFree(void *ptr);
+        char* getMacApplicationSupportDirectoryPath();
+
+        void macFree(void* ptr);
+    }
 
 #endif

--- a/libs/io/source/io/fs.cpp
+++ b/libs/io/source/io/fs.cpp
@@ -89,16 +89,24 @@ namespace wolv::io::fs {
 
     #if defined(OS_MACOS)
 
-        std::fs::path getApplicationSupportDirectoryPath() {
-            std::string exePath;
-
-            {
-                auto string = getMacApplicationSupportDirectoryPath();
-                exePath = string;
-                macFree(string);
+        namespace {
+            std::fs::path convertToPath(char* macPath) {
+                std::string path = macPath;
+                macFree(macPath);
+                return util::trim(path);
             }
+        }
 
-            return util::trim(exePath);
+        std::fs::path getMainBundleResourcesDirectoryPath() {
+            return convertToPath(getMacMainBundleResourcesDirectoryPath());
+        }
+
+        std::fs::path getMainBundleBuiltInPlugInsDirectoryPath() {
+            return convertToPath(getMacMainBundleBuiltInPlugInsDirectoryPath());
+        }
+
+        std::fs::path getApplicationSupportDirectoryPath() {
+            return convertToPath(getMacApplicationSupportDirectoryPath());
         }
 
     #endif

--- a/libs/io/source/io/fs_macos.m
+++ b/libs/io/source/io/fs_macos.m
@@ -15,6 +15,28 @@
         }
     }
 
+    char* getMacMainBundleResourcesDirectoryPath(void) {
+        @autoreleasepool {
+            const char *pathString = [[[[NSBundle mainBundle] resourceURL] path] UTF8String];
+            
+            char* result = malloc(strlen(pathString) + 1);
+            strcpy(result, pathString);
+            
+            return result;
+        }
+    }
+
+    char* getMacMainBundleBuiltInPlugInsDirectoryPath(void) {
+        @autoreleasepool {
+            const char *pathString = [[[[NSBundle mainBundle] builtInPlugInsURL] path] UTF8String];
+            
+            char* result = malloc(strlen(pathString) + 1);
+            strcpy(result, pathString);
+            
+            return result;
+        }
+    }
+
     char* getMacApplicationSupportDirectoryPath(void) {
         @autoreleasepool {
             NSError* error = nil;


### PR DESCRIPTION
This PR adds a few more accessors to `NSBundle` specific file paths on macOS.

See:
https://developer.apple.com/documentation/foundation/nsbundle/1414821-resourceurl
https://developer.apple.com/documentation/foundation/nsbundle/1409603-builtinpluginsurl