### PR TITLE
fix: Follow symlinks for macOS executable path

### DIFF
--- a/libs/io/source/io/fs_macos.m
+++ b/libs/io/source/io/fs_macos.m
@@ -6,7 +6,7 @@
 
     char* getMacExecutableDirectoryPath(void) {
         @autoreleasepool {
-            const char *pathString = [[[[[NSBundle mainBundle] executableURL] URLByDeletingLastPathComponent] path] UTF8String];
+            const char *pathString = [[[[[[NSBundle mainBundle] executableURL] URLByResolvingSymlinksInPath] URLByDeletingLastPathComponent] path] UTF8String];
 
             char *result = malloc(strlen(pathString) + 1);
             strcpy(result, pathString);


### PR DESCRIPTION
On macOS, creating a symlink to the `imhex` executable and running the program through the symlink causes ImHex to be unable to find the builtin plugins.

Example of the error:
```sh
$ ln -s imhex.app/Contents/MacOS/imhex ~/imhex
$ ~/imhex
[19:33:39] [INFO]  [main | Main]               Welcome to ImHex 1.33.2!
[19:33:39] [INFO]  [main | Main]               Compiled using commit releases/v1.33.X@8802a8e
[19:33:39] [INFO]  [main | Main]               Running on macOS 23.5.0 Darwin Kernel Version 23.5.0: Wed May  1 20:16:51 PDT 2024; root:xnu-10063.121.3~5/RELEASE_ARM64_T8103 (arm64)
[19:33:39] [INFO]  [main | Main]               Native scaling set to: 1.0
[19:33:39] [INFO]  [main | Main]               Using 'Apple' GPU
[19:33:39] [INFO]  [main | Init Tasks]         Task 'Setting up environment' finished successfully in 0 ms
[19:33:39] [INFO]  [main | Init Tasks]         Task 'Creating directories' finished successfully in 0 ms
[19:33:39] [INFO]  [main | Init Tasks]         Task 'Loading settings' finished successfully in 0 ms
[19:33:39] [ERROR] [main | Init Tasks]         No plugins found!
[19:33:39] [WARN]  [main | Init Tasks]         Task 'Loading plugins' finished unsuccessfully in 0 ms
[19:33:39] [INFO]  [main | Init Tasks]         ImHex fully started in 1ms
[19:33:39] [WARN]  [main | Main]               All tasks finished, but some failed
```

If this is fixed, macOS users installing ImHex via homebrew can have the ImHex CLI tool automatically added to their `$PATH` or manually adding to their `$PATH` without having to add `imhex.app/Contents/MacOS/` into their `$PATH`.