### PR TITLE
fix: fixes for issue #1950. 

### DIFF
--- a/libs/utils/include/wolv/utils/string.hpp
+++ b/libs/utils/include/wolv/utils/string.hpp
@@ -11,6 +11,7 @@ namespace wolv::util {
     std::vector<std::string> splitString(const std::string &string, const std::string &delimiter, bool removeEmpty = false);
     std::string combineStrings(const std::vector<std::string> &strings, const std::string &delimiter);
     std::string replaceStrings(std::string string, const std::string &search, const std::string &replace);
+    std::string replaceTabsWithSpaces(const std::string& string, u32 tabSize = 4);
     std::string wrapMonospacedString(const std::string& string, f32 charWidth, f32 maxWidth);
     std::string capitalizeString(std::string string);
 

--- a/libs/utils/source/utils/string.cpp
+++ b/libs/utils/source/utils/string.cpp
@@ -53,6 +53,24 @@ namespace wolv::util {
         return string;
     }
 
+    std::string replaceTabsWithSpaces(const std::string& string, u32 tabSize) {
+        if (tabSize == 0)
+            return string;
+
+        auto stringVector = splitString(string, "\n", false);
+        std::string result;
+        for (auto &line : stringVector) {
+            std::size_t pos = 0;
+            while ((pos = line.find('\t', pos)) != std::string::npos) {
+                auto spaces = tabSize - (pos % tabSize);
+                line.repFilace(pos, 1, std::string(spaces, ' '));
+                pos += tabSize;
+            }
+            result += line + "\n";
+        }
+        return result;
+    }
+
     std::string wrapMonospacedString(const std::string &string, const f32 charWidth, const f32 maxWidth) {
         // If the arguments don't make sense, just immediately return the incoming string.
         if (string.empty() || charWidth < 0 || maxWidth < 0) {

--- a/libs/utils/source/utils/string.cpp
+++ b/libs/utils/source/utils/string.cpp
@@ -63,7 +63,7 @@ namespace wolv::util {
             std::size_t pos = 0;
             while ((pos = line.find('\t', pos)) != std::string::npos) {
                 auto spaces = tabSize - (pos % tabSize);
-                line.repFilace(pos, 1, std::string(spaces, ' '));
+                line.replace(pos, 1, std::string(spaces, ' '));
                 pos += tabSize;
             }
             result += line + "\n";


### PR DESCRIPTION
Fixes for issue [#1950](https://github.com/WerWolv/ImHex/issues/1950). As hard as I have tried to integrate escaped tab characters '\t' into the pattern editor I have given it up in favor of just replacing them with spaces everywhere they may appear. This function allows the search and replacement of each and all the tabs present in the entire source code with an arbitrary number of spaces. This is not a fast operation for large files so it should be used only once when text is first obtained from provider.