### PR TITLE
fix: incorrect tab to spaces implementation

### DIFF
--- a/libs/utils/include/wolv/utils/string.hpp
+++ b/libs/utils/include/wolv/utils/string.hpp
@@ -13,6 +13,7 @@ namespace wolv::util {
     [[nodiscard]] std::string combineStrings(const std::vector<std::string> &strings, const std::string &delimiter);
     [[nodiscard]] std::string replaceStrings(std::string string, const std::string &search, const std::string &replace);
     [[nodiscard]] std::string replaceTabsWithSpaces(const std::string& string, u32 tabSize = 4);
+    [[nodiscard]] std::string preprocessText(const std::string &string);
     [[nodiscard]] std::string wrapMonospacedString(const std::string& string, f32 charWidth, f32 maxWidth);
     [[nodiscard]] std::string capitalizeString(std::string string);
 

--- a/libs/utils/source/utils/string.cpp
+++ b/libs/utils/source/utils/string.cpp
@@ -55,6 +55,14 @@ namespace wolv::util {
         return string;
     }
 
+    std::string preprocessText(const std::string& code) {
+        std::string result = replaceStrings(code, "\r\n", "\n");
+        result = replaceStrings(result, "\r", "\n");
+        result = replaceTabsWithSpaces(result, 4);
+
+        return result;
+    }
+
     std::string replaceTabsWithSpaces(const std::string& string, u32 tabSize) {
         if (tabSize == 0 || string.empty() || string.find('\t') == std::string::npos)
             return string;

--- a/libs/utils/source/utils/string.cpp
+++ b/libs/utils/source/utils/string.cpp
@@ -6,7 +6,7 @@
 namespace wolv::util {
 
     std::vector<std::string> splitString(const std::string &string, const std::string &delimiter, bool removeEmpty) {
-        if (delimiter.empty()) {
+        if (delimiter.empty() || string.empty()) {
             return { string };
         }
 


### PR DESCRIPTION
Was using a fixed size of 4 instead of depending on column. Added function to take care of the test preprocessing.