### PR TITLE
`ChangeTracker`'s move assigment operator can cause `std::thread::operator=(std::thread&&)` to call `std::terminate`.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libs/utils/lib/jthread/jthread"]
+	path = libs/utils/lib/jthread/jthread
+	url = https://github.com/josuttis/jthread

--- a/libs/io/include/wolv/io/file.hpp
+++ b/libs/io/include/wolv/io/file.hpp
@@ -8,7 +8,7 @@
 #include <cstdio>
 #include <optional>
 #include <string>
-#include <thread>
+#include <jthread.hpp>
 #include <stop_token>
 #include <mutex>
 #include <condition_variable>

--- a/libs/io/include/wolv/io/file.hpp
+++ b/libs/io/include/wolv/io/file.hpp
@@ -108,7 +108,7 @@ namespace wolv::io {
     class StoppableSleep {
     public:
         StoppableSleep(const std::stop_token &st) : m_st(st) {}
-        bool sleep(int dur);
+        bool sleep(u32 duration);
         bool shouldStop() {
             return m_st.stop_requested();
         }
@@ -122,7 +122,7 @@ namespace wolv::io {
     class ChangeTracker {
     public:
         ChangeTracker() = default;
-        explicit ChangeTracker(std::fs::path path) : m_path(std::move(path)) { };
+        explicit ChangeTracker(std::fs::path path) : m_path(std::move(path)) { }
         explicit ChangeTracker(const File &file) : m_path(file.getPath()) { }
         ~ChangeTracker() { this->stopTracking(); }
 

--- a/libs/io/include/wolv/io/file.hpp
+++ b/libs/io/include/wolv/io/file.hpp
@@ -124,7 +124,7 @@ namespace wolv::io {
         static void trackImpl(const bool &stopped, const std::fs::path &path, const std::function<void()> &callback);
 
     private:
-        bool m_stopped = false;
+        bool m_stopWorkerThread = false;
         std::fs::path m_path;
         std::thread m_thread;
     };

--- a/libs/io/include/wolv/io/file.hpp
+++ b/libs/io/include/wolv/io/file.hpp
@@ -113,7 +113,7 @@ namespace wolv::io {
         ChangeTracker(ChangeTracker &&) = default;
 
         ChangeTracker& operator=(const ChangeTracker &) = delete;
-        ChangeTracker& operator=(ChangeTracker &&) = default;
+        ChangeTracker& operator=(ChangeTracker &&other) noexcept;
 
         [[nodiscard]] const std::fs::path& getPath() const { return this->m_path; }
 

--- a/libs/io/include/wolv/io/file.hpp
+++ b/libs/io/include/wolv/io/file.hpp
@@ -9,7 +9,6 @@
 #include <optional>
 #include <string>
 #include <jthread.hpp>
-#include <stop_token>
 #include <mutex>
 #include <condition_variable>
 #include <vector>

--- a/libs/io/include/wolv/io/file.hpp
+++ b/libs/io/include/wolv/io/file.hpp
@@ -122,7 +122,7 @@ namespace wolv::io {
     class ChangeTracker {
     public:
         ChangeTracker() = default;
-        explicit ChangeTracker(std::fs::path path)  : m_path(std::move(path)) { };
+        explicit ChangeTracker(std::fs::path path) : m_path(std::move(path)) { };
         explicit ChangeTracker(const File &file) : m_path(file.getPath()) { }
         ~ChangeTracker() { this->stopTracking(); }
 

--- a/libs/io/source/io/file.cpp
+++ b/libs/io/source/io/file.cpp
@@ -1,3 +1,4 @@
+#include <utility>
 #include <wolv/io/file.hpp>
 #include <wolv/utils/string.hpp>
 
@@ -119,6 +120,15 @@ namespace wolv::io {
 
     size_t File::writeU8StringAtomic(u64 address, const std::u8string &string) {
         return writeBufferAtomic(address, reinterpret_cast<const u8*>(string.data()), string.size());
+    }
+
+    ChangeTracker& ChangeTracker::operator=(ChangeTracker &&other) noexcept {
+        stopTracking();
+        this->m_stopped = false;
+        m_path = std::move(other.m_path);
+        m_thread = std::move(other.m_thread);
+
+        return *this;
     }
 
     void ChangeTracker::startTracking(const std::function<void()> &callback) {

--- a/libs/io/source/io/file.cpp
+++ b/libs/io/source/io/file.cpp
@@ -123,7 +123,7 @@ namespace wolv::io {
         return writeBufferAtomic(address, reinterpret_cast<const u8*>(string.data()), string.size());
     }
 
-    bool StoppableSleep::sleep(int dur) {
+    bool StoppableSleep::sleep(u32 duration) {
         std::unique_lock lk(m_mtx);
         bool shouldStop = false;
 
@@ -132,7 +132,7 @@ namespace wolv::io {
             shouldStop = true;
         });
 
-        m_cv.wait_for(lk, std::chrono::milliseconds(dur), [&]{return shouldStop;});
+        m_cv.wait_for(lk, std::chrono::milliseconds(duration), [&]{return shouldStop;});
 
         return shouldStop;
     }

--- a/libs/io/source/io/file.cpp
+++ b/libs/io/source/io/file.cpp
@@ -124,7 +124,7 @@ namespace wolv::io {
 
     ChangeTracker& ChangeTracker::operator=(ChangeTracker &&other) noexcept {
         stopTracking();
-        this->m_stopped = false;
+        m_stopWorkerThread = false;
         m_path = std::move(other.m_path);
         m_thread = std::move(other.m_thread);
 
@@ -132,19 +132,19 @@ namespace wolv::io {
     }
 
     void ChangeTracker::startTracking(const std::function<void()> &callback) {
-        if (this->m_path.empty())
+        if (m_path.empty())
             return;
 
-        this->m_thread = std::thread([this, callback]() {
-            trackImpl(this->m_stopped, this->m_path, callback);
+        m_stopWorkerThread = false;
+        m_thread = std::thread([this, callback]() {
+            trackImpl(m_stopWorkerThread, m_path, callback);
         });
     }
 
     void ChangeTracker::stopTracking() {
-        this->m_stopped = true;
-
-        if (this->m_thread.joinable())
-            this->m_thread.join();
+        m_stopWorkerThread = true;
+        if (m_thread.joinable())
+            m_thread.join();
     }
 
 }

--- a/libs/io/source/io/file_unix.cpp
+++ b/libs/io/source/io/file_unix.cpp
@@ -219,7 +219,7 @@ namespace wolv::io {
 
             const timespec timeout = { 0, 0 };
 			StoppableSleep sleeper(st);
-            for (;;) {
+            while (true) {
                 if (sleeper.sleep(1000)) {
 					break;
 				}
@@ -253,7 +253,7 @@ namespace wolv::io {
             pollfd pollDescriptor = { fileDescriptor, POLLIN, 0 };
 
             StoppableSleep sleeper(st);
-            for (;;) {
+            while (true) {
                 if (sleeper.sleep(1000)) {
 					break;
 				}

--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -4,15 +4,17 @@ project(libwolv-utils)
 add_library(${PROJECT_NAME} STATIC
         source/utils/string.cpp
 )
+
+add_subdirectory(lib/jthread)
+
 target_include_directories(${PROJECT_NAME} PUBLIC include)
-target_link_libraries(${PROJECT_NAME} PUBLIC wolv::types)
+target_link_libraries(${PROJECT_NAME} PUBLIC wolv::types jthread)
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
 
 string(REPLACE "libwolv-" "" PROJECT_NAME_SPACE ${PROJECT_NAME})
 add_library(wolv::${PROJECT_NAME_SPACE} ALIAS ${PROJECT_NAME})
 
-add_subdirectory(lib/jthread)
-target_link_libraries(libwolv INTERFACE ${PROJECT_NAME} jthread)
+target_link_libraries(libwolv INTERFACE ${PROJECT_NAME})
 
 
 if (WIN32)

--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -11,7 +11,9 @@ set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
 string(REPLACE "libwolv-" "" PROJECT_NAME_SPACE ${PROJECT_NAME})
 add_library(wolv::${PROJECT_NAME_SPACE} ALIAS ${PROJECT_NAME})
 
-target_link_libraries(libwolv INTERFACE ${PROJECT_NAME})
+add_subdirectory(lib/jthread)
+target_link_libraries(libwolv INTERFACE ${PROJECT_NAME} jthread)
+
 
 if (WIN32)
     set_target_properties(${PROJECT_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)

--- a/libs/utils/lib/jthread/CMakeLists.txt
+++ b/libs/utils/lib/jthread/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(jthread)
+
+add_library(jthread INTERFACE)
+target_include_directories(jthread INTERFACE includes)

--- a/libs/utils/lib/jthread/includes/jthread.hpp
+++ b/libs/utils/lib/jthread/includes/jthread.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#if __cpp_lib_jthread >= 201911L
+    #include <thread>
+#else
+    #define __stop_callback_base __stop_callback_base_j
+    #define __stop_state __stop_state_j
+    #include "../jthread/source/jthread.hpp"
+    #undef __stop_callback_base
+    #undef __stop_state
+#endif

--- a/libs/utils/lib/jthread/includes/jthread.hpp
+++ b/libs/utils/lib/jthread/includes/jthread.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <version>
+
 #if __cpp_lib_jthread >= 201911L
     #include <thread>
 #else


### PR DESCRIPTION
### Issue

`ChangeTracker`'s move assigment operator can cause `std::thread::operator=(std::thread&&)` to call `std::terminate`.

### Repo

See [here](https://github.com/WerWolv/ImHex/issues/2452)

## The fix

Make `ChangeTracker`'s move assignment operator stop the left hand side thread before the move. 

## More info

The cause is the change tracking code. A move assigment operator call for a `std::thread` has a joinable thread on the left side.

## Call stack
```
 .
 .
 .
std::__terminate c++config.h:352
std::thread::operator= std_thread.h:197 // <-----HERE
wolv::io::ChangeTracker::operator= file.hpp:116 // <-----HERE
hex::plugin::builtin::ViewPatternEditor::loadPatternFile view_pattern_editor.cpp:1595
operator() view_pattern_editor.cpp:2574
 .
 .
 .
hex::ui::PopupNamedFileChooserBase<hex::ui::PopupNamedFileChooser>::drawContent()::{lambda(auto:1 const&)#1}::operator()<std::filesystem::__cxx11::path>(std::filesystem::__cxx11::path const&) const popup_file_chooser.hpp:106
 .
 .
 .
std::function::operator() std_function.h:593
hex::fs::openFileBrowser fs.cpp:267
hex::ui::PopupNamedFileChooserBase::drawContent popup_file_chooser.hpp:105
operator() window.cpp:583
hex::Window::frameBegin window.cpp:606
hex::Window::fullFrame window.cpp:208
hex::Window::loop window.cpp:304
hex::init::runImHex desktop.cpp:54
main main.cpp:67
 .
 .
 .
```

## The call to `std::__terminate` (std_thread.h:197)
```c++
    thread& operator=(thread&& __t) noexcept
    {
      if (joinable())
	std::__terminate(); // <-----HERE
      swap(__t);
      return *this;
    }
```

## The code for the `default`ed move assignment operator
```
wolv::io::ChangeTracker::operator=(wolv::io::ChangeTracker&&):
	push   %rbp                     
	mov    %rsp,%rbp                
	sub    $0x20,%rsp               
	mov    %rcx,0x10(%rbp)          
	mov    %rdx,0x18(%rbp)          
	mov    0x18(%rbp),%rax          
	movzbl (%rax),%edx              
	mov    0x10(%rbp),%rax          
	mov    %dl,(%rax)               
	mov    0x18(%rbp),%rax          
	lea    0x8(%rax),%rdx           
	mov    0x10(%rbp),%rax          
	add    $0x8,%rax                
	mov    %rax,%rcx                
	call   0x7ffa1fd4fdc0 <std::filesystem::__cxx11::path::operator=(std::filesystem::__cxx11::path&&)>
	mov    0x18(%rbp),%rax          
	lea    0x30(%rax),%rdx          
	mov    0x10(%rbp),%rax          
	add    $0x30,%rax               
	mov    %rax,%rcx                
	call   0x7ffa1fdd1150 <std::thread::operator=(std::thread&&)> // <-----HERE
	mov    0x10(%rbp),%rax          
	add    $0x20,%rsp               
	pop    %rbp                     
	ret
```