### PR TITLE
libwolv: Fixed thread pool tests

### DIFF
--- a/libs/utils/include/wolv/utils/thread_pool.hpp
+++ b/libs/utils/include/wolv/utils/thread_pool.hpp
@@ -6,6 +6,9 @@
 #include <list>
 #include <functional>
 #include <condition_variable>
+#include <atomic>
+
+#include <wolv/types.hpp>
 
 namespace wolv::util {
 
@@ -141,6 +144,6 @@ namespace wolv::util {
             std::condition_variable m_condition;
             std::atomic<bool> m_stop = false;
             std::atomic<bool> m_stopTasks = false;
-            std::atomic<u32> m_threadsAvailable = 0;
+            std::atomic<wolv::u32> m_threadsAvailable = 0;
         };
 }


### PR DESCRIPTION
The thread pool tests in  libwolv were failing. Small changes to get it to build properly.
Now all tests pass.

```
$ ctest --output-on-failure
Test project C:/projects/SteveImHex/lib/external/libwolv/build-debug
      Start  1: IO/BasicFileAccess
 1/30 Test  #1: IO/BasicFileAccess ...............   Passed    0.03 sec
      Start  2: IO/FileVectorOps
 2/30 Test  #2: IO/FileVectorOps .................   Passed    0.02 sec
      Start  3: IO/FileStringOps
 3/30 Test  #3: IO/FileStringOps .................   Passed    0.02 sec
      Start  4: IO/FileClone
 4/30 Test  #4: IO/FileClone .....................   Passed    0.03 sec
      Start  5: IO/FileAtomicStringOps
 5/30 Test  #5: IO/FileAtomicStringOps ...........   Passed    0.02 sec
      Start  6: IO/FileAtomicVectorOps
 6/30 Test  #6: IO/FileAtomicVectorOps ...........   Passed    0.02 sec
      Start  7: IO/FileSize
 7/30 Test  #7: IO/FileSize ......................   Passed    0.03 sec
      Start  8: IO/FileMove
 8/30 Test  #8: IO/FileMove ......................   Passed    0.02 sec
      Start  9: IO/FileHandle
 9/30 Test  #9: IO/FileHandle ....................   Passed    0.02 sec
      Start 10: IO/FileInfo
10/30 Test #10: IO/FileInfo ......................   Passed    0.02 sec
      Start 11: IO/EmptyFileTracker
11/30 Test #11: IO/EmptyFileTracker ..............   Passed    0.01 sec
      Start 12: IO/FileTracker
12/30 Test #12: IO/FileTracker ...................   Passed    1.16 sec
      Start 13: IO/CloneFileTracker
13/30 Test #13: IO/CloneFileTracker ..............   Passed    2.10 sec
      Start 14: IO/FsGetExecPath
14/30 Test #14: IO/FsGetExecPath .................   Passed    0.05 sec
      Start 15: IO/FsToNormalizedPath
15/30 Test #15: IO/FsToNormalizedPath ............   Passed    0.05 sec
      Start 16: IO/BufferedReader
16/30 Test #16: IO/BufferedReader ................   Passed    0.03 sec
      Start 17: HASH/UUID
17/30 Test #17: HASH/UUID ........................   Passed    0.04 sec
      Start 18: HASH/CRC
18/30 Test #18: HASH/CRC .........................   Passed    0.02 sec
      Start 19: HASH/CRC_Reflect
19/30 Test #19: HASH/CRC_Reflect .................   Passed    0.01 sec
      Start 20: UTILS/String_Split
20/30 Test #20: UTILS/String_Split ...............   Passed    0.01 sec
      Start 21: UTILS/String_Combine
21/30 Test #21: UTILS/String_Combine .............   Passed    0.01 sec
      Start 22: UTILS/String_Replace
22/30 Test #22: UTILS/String_Replace .............   Passed    0.01 sec
      Start 23: UTILS/String_Trim
23/30 Test #23: UTILS/String_Trim ................   Passed    0.02 sec
      Start 24: UTILS/String_Strnlen
24/30 Test #24: UTILS/String_Strnlen .............   Passed    0.02 sec
      Start 25: UTILS/String_MonoSpaceWrap
25/30 Test #25: UTILS/String_MonoSpaceWrap .......   Passed    0.02 sec
      Start 26: UTILS/Guard_ScopeGuard
26/30 Test #26: UTILS/Guard_ScopeGuard ...........   Passed    0.02 sec
      Start 27: UTILS/Lock
27/30 Test #27: UTILS/Lock .......................   Passed    0.01 sec
      Start 28: UTILS/ThreadPool
28/30 Test #28: UTILS/ThreadPool .................   Passed    0.01 sec
      Start 29: Common/TestSucceeding
29/30 Test #29: Common/TestSucceeding ............   Passed    0.02 sec
      Start 30: Common/TestFailing
30/30 Test #30: Common/TestFailing ...............   Passed    0.01 sec

100% tests passed, 0 tests failed out of 30

Total Test time (real) =   3.94 sec
```