### PR TITLE
Fix `Interval::operator<` to satisfy strict weak ordering

### DIFF
--- a/libs/containers/include/wolv/container/interval_tree.hpp
+++ b/libs/containers/include/wolv/container/interval_tree.hpp
@@ -38,7 +38,7 @@ namespace wolv::container {
             }
 
             bool operator<(const Interval& other) const {
-                return end < other.start;
+                return std::tie(start, end) < std::tie(other.start, other.end);
             }
         };
 


### PR DESCRIPTION
## Summary

`IntervalTree::Interval::operator<` currently uses:

```cpp
return end < other.start;
```

This encodes a useful interval relation, but it does not define a strict weak ordering, which is what C++ ordering-based algorithms and containers expect from `operator<`.

In particular, overlapping intervals are treated as "equivalent" (`!(a < b) && !(b < a)`), but that induced equivalence is not transitive.

This PR proposes a minimal fix:

```cpp
return std::tie(start, end) < std::tie(other.start, other.end);
```

That gives `Interval` a proper lexicographic ordering by `(start, end)`.

## Violation Witness

Consider:

- `A = [0, 3]`
- `B = [2, 5]`
- `C = [4, 7]`

With the current comparator:

- `A < B` is false and `B < A` is false, because they overlap
- `B < C` is false and `C < B` is false, because they overlap
- `A < C` is true, because `A.end < C.start`

So `A ~ B` and `B ~ C`, but `A !~ C`.

That violates transitivity of equivalence, so `operator<` is not a strict weak ordering.

## Potential Outcomes

If `Interval::operator<` is ever used with APIs that require strict weak ordering, behavior may be incorrect or undefined, including:

- `std::sort`
- `std::set`
- `std::map`
- any ordering-based utility using `std::less<Interval>`

Even if current internal usage does not rely on this today, keeping a non-SWO `operator<` on a public type is a footgun for future use and downstream consumers.

## Proposed Fix

This PR replaces:

```cpp
return end < other.start;
```

with:

```cpp
return std::tie(start, end) < std::tie(other.start, other.end);
```

This is a minimal, conventional fix that makes `operator<` valid for C++ ordering semantics.

## Note On Intent / Behavior

If the intended use of sorted intervals already assumes that intervals are non-overlapping, then switching to lexicographic ordering should not change the effective ordering behavior for that valid input domain.

For non-overlapping intervals, both the current relation and the proposed lexicographic ordering preserve the natural left-to-right ordering by position. The proposed change mainly makes `operator<` a valid strict weak ordering for C++ semantics, instead of relying on a relation that breaks down once overlapping intervals are compared.

So while this changes the meaning of `operator<` in a formal sense, it should preserve the expected behavior in the case where sorted intervals are already assumed to be non-overlapping.
