### PR TITLE
fix: read/write files larger than 0x7ffff000 bytes on linux

### DIFF
--- a/libs/io/source/io/file_unix.cpp
+++ b/libs/io/source/io/file_unix.cpp
@@ -126,7 +126,18 @@ namespace wolv::io {
         if (!isValid())
             return -1;
 
-        return pread(m_handle, buffer, size, address);
+        ssize_t acc = 0;
+        while (acc < size) {
+            const auto bytes = pread(m_handle, buffer, size - acc, address);
+            if (bytes <= 0) {
+                break;
+            }
+
+            acc += bytes;
+            address += bytes;
+            buffer += bytes;
+        }
+        return acc;
     }
 
 
@@ -143,7 +154,18 @@ namespace wolv::io {
             return -1;
 
         m_sizeValid = false;
-        return pwrite(m_handle, buffer, size, address);
+        ssize_t acc = 0;
+        while (acc < size) {
+            const auto bytes = pwrite(m_handle, buffer, size - acc, address);
+            if (bytes <= 0) {
+                break;
+            }
+
+            acc += bytes;
+            address += bytes;
+            buffer += bytes;
+        }
+        return acc;
     }
 
     void File::setSize(u64 size) {


### PR DESCRIPTION
Fixes https://github.com/WerWolv/ImHex/issues/2768

according to `man 2 read` on a linux system:

```
       On Linux, read() (and similar system calls) will transfer  at  most  0x7ffff000
       (2,147,479,552)  bytes,  returning  the  number  of bytes actually transferred.
       (This is true on both 32-bit and 64-bit systems.)
```

same is true for write.

while pread does not have the note, it still is truncated to 0x7ffff000 bytes