### PR TITLE
feat: add replaceSpacesWithTabs, add tabSize to preprocessText

### DIFF
--- a/libs/utils/include/wolv/utils/string.hpp
+++ b/libs/utils/include/wolv/utils/string.hpp
@@ -15,7 +15,8 @@ namespace wolv::util {
     [[nodiscard]] std::string combineStrings(const std::vector<std::string> &strings, const std::string &delimiter);
     [[nodiscard]] std::string replaceStrings(std::string string, const std::string &search, const std::string &replace);
     [[nodiscard]] std::string replaceTabsWithSpaces(const std::string& string, u32 tabSize = 4);
-    [[nodiscard]] std::string preprocessText(const std::string &string);
+    [[nodiscard]] std::string replaceSpacesWithTabs(const std::string& string, u32 tabSize = 4, bool trimWhitespace = false);
+    [[nodiscard]] std::string preprocessText(const std::string &string, u32 tabSize = 4);
     [[nodiscard]] std::string wrapMonospacedString(const std::string& string, f32 charWidth, f32 maxWidth);
     [[nodiscard]] std::string capitalizeString(std::string string);
 

--- a/libs/utils/source/utils/string.cpp
+++ b/libs/utils/source/utils/string.cpp
@@ -54,16 +54,16 @@ namespace wolv::util {
         return string;
     }
 
-    std::string preprocessText(const std::string& code) {
+    std::string preprocessText(const std::string& code, u32 tabSize) {
         std::string result = replaceStrings(code, "\r\n", "\n");
         result = replaceStrings(result, "\r", "\n");
-        result = replaceTabsWithSpaces(result, 4);
+        result = replaceTabsWithSpaces(result, tabSize);
 
         return result;
     }
 
     std::string replaceTabsWithSpaces(const std::string& string, u32 tabSize) {
-        if (tabSize == 0 || string.empty() || string.find('\t') == std::string::npos)
+        if (tabSize == 0 || string.empty() || !string.contains('\t'))
             return string;
 
         auto stringVector = splitString(string, "\n", false);
@@ -78,6 +78,59 @@ namespace wolv::util {
             result += line + '\n';
         }
         result.pop_back();
+        return result;
+    }
+
+    std::string replaceSpacesWithTabs(const std::string& string, u32 tabSize, bool trimWhitespace) {
+        if (tabSize == 0 || string.empty() || !string.contains(' ')) {
+            return string;
+        }
+
+        std::string result;
+        result.reserve(string.size());
+        u32 col = 0;
+        u32 spaces = 0;
+
+        for (const char c : string) {
+            if (c == ' ') {
+                spaces++;
+                col++;
+                if (col % tabSize == 0 && spaces == tabSize) {
+                    result += '\t';
+                    spaces = 0;
+                }
+            } else if (c == '\n') {
+                if (!trimWhitespace) {
+                    result.append(spaces, ' ');
+                }
+
+                result += c;
+                col = 0;
+                spaces = 0;
+            } else if (c == '\t') {
+                result.append(spaces, ' ');
+                result += '\t';
+                col += tabSize - col % tabSize;
+                spaces = 0;
+            } else {
+                // don't insert tabs for a single space
+                if (col > 0 && col % tabSize == 0 && spaces > 1) {
+                    result += '\t';
+                    spaces = 0;
+                } else {
+                    result.append(spaces, ' ');
+                }
+
+                result += c;
+                col = 0;
+                spaces = 0;
+            }
+        }
+
+        if (!trimWhitespace) {
+            result.append(spaces, ' ');
+        }
+
         return result;
     }
 

--- a/libs/utils/source/utils/string.cpp
+++ b/libs/utils/source/utils/string.cpp
@@ -102,6 +102,8 @@ namespace wolv::util {
             } else if (c == '\n') {
                 if (!trimWhitespace) {
                     result.append(spaces, ' ');
+                } else {
+                    result.erase(result.find_last_not_of('\t') + 1);
                 }
 
                 result += c;
@@ -129,6 +131,8 @@ namespace wolv::util {
 
         if (!trimWhitespace) {
             result.append(spaces, ' ');
+        } else {
+            result.erase(result.find_last_not_of('\t') + 1);
         }
 
         return result;

--- a/tests/utils/source/string.cpp
+++ b/tests/utils/source/string.cpp
@@ -89,6 +89,46 @@ TEST_SEQUENCE("String_Replace") {
     TEST_SUCCESS();
 };
 
+// test replaceSpacesWithTabs()
+TEST_SEQUENCE("String_ReplaceSpacesWithTabs") {
+    // 0 occurence
+    {
+        TEST_ASSERT(replaceSpacesWithTabs("house\n\ttree\n\t\tmirror", 4, false) == "house\n\ttree\n\t\tmirror");
+    }
+
+    // mixed a
+    {
+        TEST_ASSERT(replaceSpacesWithTabs("house\n    tree\n    \tmirror", 4, false) == "house\n\ttree\n\t\tmirror");
+    }
+
+    // mixed b
+    {
+        TEST_ASSERT(replaceSpacesWithTabs("house\n    tree\n  \t    mirror", 4, false) == "house\n\ttree\n  \t\tmirror");
+    }
+
+    // mixed c
+    {
+        TEST_ASSERT(replaceSpacesWithTabs("house\n    tree\n  \t  mirror", 4, false) == "house\n\ttree\n  \t  mirror");
+    }
+
+    // all space
+    {
+        TEST_ASSERT(replaceSpacesWithTabs("house\n    tree\n        mirror", 4, false) == "house\n\ttree\n\t\tmirror");
+    }
+
+    // trim whitespace a
+    {
+        TEST_ASSERT(replaceSpacesWithTabs("house\n    tree  \n        mirror  ", 4, true) == "house\n\ttree\n\t\tmirror");
+    }
+
+    // trim whitespace b
+    {
+        TEST_ASSERT(replaceSpacesWithTabs("house\n    tree  \n        mirror    ", 4, true) == "house\n\ttree\n\t\tmirror");
+    }
+
+    TEST_SUCCESS();
+};
+
 // test trim()
 TEST_SEQUENCE("String_Trim") {
     // nothing to trim


### PR DESCRIPTION
preprocessText with tab size can not trivially used by imhex yet because m_tabSize is controlled by an instance variable not accessible to the decode lambda, but it does need to be in this call arg.

replaceSpacesWithTabs essentially does the inverse of replaceTabsWithSpaces but can't trivially use optimized replacement due to mixed tab column logic.